### PR TITLE
Priority plugin: Set default docker compose project name for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking changes
+- Priority plugin: 'auditor' and 'prometheus' configuration has to be present in the config file (#456) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Security
 
 ### Added
+- Priority plugin: Add prometheus data exporter (#456) ([@raghuvar-vijay](https://github.com/raghuvar-vijay))
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,17 +372,24 @@ dependencies = [
 name = "auditor-priority-plugin"
 version = "0.2.0"
 dependencies = [
+ "actix-web",
+ "actix-web-opentelemetry",
  "anyhow",
  "auditor",
  "chrono",
  "config",
  "num-traits",
+ "opentelemetry",
+ "opentelemetry-prometheus",
+ "opentelemetry_api",
+ "prometheus",
  "serde",
  "serde-aux",
  "serde_with",
  "shell-words",
  "tokio",
  "tracing",
+ "tracing-actix-web",
  "tracing-subscriber",
  "uuid",
 ]

--- a/auditor/configuration/priority-plugin/base.yml
+++ b/auditor/configuration/priority-plugin/base.yml
@@ -16,3 +16,11 @@ group_mapping:
 commands:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
   - "echo '{group}: {priority}'"
+prometheus:
+  enable: true
+  addr: 0.0.0.0
+  port: 9090
+  frequency: 3600
+  metrics:
+    - ResourceUsage
+    - Priority

--- a/auditor/configuration/priority-plugin/base.yml
+++ b/auditor/configuration/priority-plugin/base.yml
@@ -1,5 +1,6 @@
-addr: "localhost"
-port: 8000
+auditor:
+  addr: "localhost"
+  port: 8000
 components:
   NumCPUs: "HEPSPEC"
 min_priority: 1

--- a/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
@@ -1,5 +1,6 @@
-addr: "host.docker.internal"
-port: 8000
+auditor:
+  addr: "host.docker.internal"
+  port: 8000
 components:
   NumCPUs: "HEPSPEC"
 min_priority: 1

--- a/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_fullspread.yaml
@@ -21,3 +21,11 @@ group_mapping:
     - "part6"
 command:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
+prometheus:
+  enable: true
+  addr: 0.0.0.0
+  port: 9090
+  frequency: 3600
+  metrics:
+    - ResourceUsage
+    - Priority

--- a/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
@@ -1,5 +1,6 @@
-addr: "host.docker.internal"
-port: 8000
+auditor:
+  addr: "host.docker.internal"
+  port: 8000
 components:
   NumCPUs: "HEPSPEC"
 min_priority: 1

--- a/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
+++ b/containers/docker-centos7-slurm/plugin_config_scaledbysum.yaml
@@ -21,3 +21,11 @@ group_mapping:
     - "part6"
 command:
   - "/usr/bin/scontrol update PartitionName={1} PriorityJobFactor={priority}"
+prometheus:
+  enable: true
+  addr: 0.0.0.0
+  port: 9090
+  frequency: 3600
+  metrics:
+    - ResourceUsage
+    - Priority

--- a/plugins/priority/Cargo.toml
+++ b/plugins/priority/Cargo.toml
@@ -31,6 +31,7 @@ strip = true
 
 [dependencies]
 auditor = { path = "../../auditor", version = "0.2.0" }
+actix-web = "4.4.0"
 config = "0.13"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3" }
@@ -43,5 +44,11 @@ uuid = { version = "1.4", features = ["v4"] }
 num-traits = "^0.2"
 anyhow = "1"
 shell-words = "^1"
+actix-web-opentelemetry = { version = "0.15", features = ["metrics", "metrics-prometheus"] }
+opentelemetry = "0.20"
+opentelemetry_api = "0.20.0"
+tracing-actix-web = "0.7"
+prometheus = "0.13"
+opentelemetry-prometheus = "0.13"
 
 [dev-dependencies]

--- a/plugins/priority/src/configuration.rs
+++ b/plugins/priority/src/configuration.rs
@@ -20,11 +20,7 @@ pub enum ComputationMode {
 #[serde_with::serde_as]
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct Settings {
-    #[serde(default = "default_addr")]
-    pub addr: String,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    #[serde(default = "default_port")]
-    pub port: u16,
+    pub auditor: AuditorSettings,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     #[serde(default = "default_timeout")]
     pub timeout: i64,
@@ -45,6 +41,55 @@ pub struct Settings {
     #[serde(default = "default_log_level")]
     #[serde(deserialize_with = "deserialize_log_level")]
     pub log_level: LevelFilter,
+    pub prometheus: PrometheusSettings,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct AuditorSettings {
+    #[serde(default = "default_addr")]
+    pub addr: String,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct PrometheusSettings {
+    #[serde(default = "default_enable_option")]
+    pub enable: bool,
+    #[serde(default = "default_prometheus_addr")]
+    pub addr: String,
+    #[serde(default = "default_prometheus_port")]
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub port: u16,
+    #[serde(default = "default_prometheus_frequency")]
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    pub frequency: chrono::Duration,
+    pub metrics: Vec<PrometheusMetricsOptions>,
+}
+
+#[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrometheusMetricsOptions {
+    ResourceUsage,
+    Priority,
+}
+
+fn default_enable_option() -> bool {
+    true
+}
+
+fn default_prometheus_addr() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_prometheus_port() -> u16 {
+    9090
+}
+
+fn default_prometheus_frequency() -> chrono::Duration {
+    chrono::Duration::seconds(3600)
 }
 
 fn default_log_level() -> LevelFilter {

--- a/plugins/priority/src/main.rs
+++ b/plugins/priority/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cloned_request_metrics = request_metrics.clone();
 
-    let enable_prometheus = config.prometheus.enable.clone();
+    let enable_prometheus = config.prometheus.enable;
 
     tokio::spawn(async move {
         let configuration = config.clone();

--- a/plugins/priority/src/metrics/mod.rs
+++ b/plugins/priority/src/metrics/mod.rs
@@ -53,7 +53,7 @@ impl PrometheusExporterConfig {
         &self,
         resources: &HashMap<String, f64>,
         priorities: &HashMap<String, i64>,
-        metrics: &Vec<PrometheusMetricsOptions>,
+        metrics: &[PrometheusMetricsOptions],
     ) -> Result<(), anyhow::Error> {
         for metric in metrics.iter() {
             match metric {
@@ -68,7 +68,7 @@ impl PrometheusExporterConfig {
                     for (priority, value) in priorities {
                         self.priority_metric
                             .with_label_values(&[priority])
-                            .set(*value as i64);
+                            .set(*value);
                     }
                 }
             };

--- a/plugins/priority/src/metrics/mod.rs
+++ b/plugins/priority/src/metrics/mod.rs
@@ -1,0 +1,78 @@
+use crate::configuration::PrometheusMetricsOptions;
+use opentelemetry::sdk::metrics::MeterProvider;
+use prometheus::Registry;
+use prometheus::{IntGaugeVec, Opts};
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct PrometheusExporterConfig {
+    pub provider: MeterProvider,
+    pub prom_registry: Registry,
+    pub resource_metric: IntGaugeVec,
+    pub priority_metric: IntGaugeVec,
+}
+
+impl PrometheusExporterConfig {
+    #[tracing::instrument(name = "Initializing Prometheus exporter")]
+    pub fn build() -> Result<PrometheusExporterConfig, anyhow::Error> {
+        let prom_registry = Registry::new();
+
+        let metrics_exporter = opentelemetry_prometheus::exporter()
+            .with_registry(prom_registry.clone())
+            .build()?;
+
+        let resource_metric = IntGaugeVec::new(
+            Opts::new("resource_usage", "Resource usage metrics"),
+            &["resource"],
+        )
+        .unwrap();
+
+        let priority_metric =
+            IntGaugeVec::new(Opts::new("priority", "Priority metrics"), &["priority"]).unwrap();
+
+        prom_registry
+            .register(Box::new(resource_metric.clone()))
+            .unwrap();
+        prom_registry
+            .register(Box::new(priority_metric.clone()))
+            .unwrap();
+
+        let provider = MeterProvider::builder()
+            .with_reader(metrics_exporter)
+            .build();
+
+        Ok(PrometheusExporterConfig {
+            provider,
+            prom_registry,
+            resource_metric,
+            priority_metric,
+        })
+    }
+
+    pub async fn update_prometheus_metrics(
+        &self,
+        resources: &HashMap<String, f64>,
+        priorities: &HashMap<String, i64>,
+        metrics: &Vec<PrometheusMetricsOptions>,
+    ) -> Result<(), anyhow::Error> {
+        for metric in metrics.iter() {
+            match metric {
+                PrometheusMetricsOptions::ResourceUsage => {
+                    for (resource, value) in resources {
+                        self.resource_metric
+                            .with_label_values(&[resource])
+                            .set(*value as i64);
+                    }
+                }
+                PrometheusMetricsOptions::Priority => {
+                    for (priority, value) in priorities {
+                        self.priority_metric
+                            .with_label_values(&[priority])
+                            .set(*value as i64);
+                    }
+                }
+            };
+        }
+        Ok(())
+    }
+}

--- a/plugins/priority/src/startup.rs
+++ b/plugins/priority/src/startup.rs
@@ -1,0 +1,31 @@
+use crate::metrics::PrometheusExporterConfig;
+use actix_web::dev::Server;
+use actix_web::{web, App, HttpServer};
+use actix_web_opentelemetry::{PrometheusMetricsHandler, RequestMetrics};
+use opentelemetry_api::global;
+use std::net::TcpListener;
+use tracing_actix_web::TracingLogger;
+
+/// Configures and starts the HttpServer
+pub fn run(
+    listener: TcpListener,
+    request_metrics: PrometheusExporterConfig,
+) -> Result<Server, anyhow::Error> {
+    global::set_meter_provider(request_metrics.provider);
+
+    let server = HttpServer::new(move || {
+        App::new()
+            // Logging middleware
+            .wrap(TracingLogger::default())
+            .wrap(RequestMetrics::default())
+            .route(
+                "/metrics",
+                web::get().to(PrometheusMetricsHandler::new(
+                    request_metrics.prom_registry.clone(),
+                )),
+            )
+    })
+    .listen(listener)?
+    .run();
+    Ok(server)
+}

--- a/scripts/test_priority_plugin.sh
+++ b/scripts/test_priority_plugin.sh
@@ -156,22 +156,22 @@ function fill_auditor() {
 
 function test_priority_plugin_fullspread() {
 	sleep 1
-	docker exec -e RUST_LOG=debug auditor-slurm-1 /auditor-priority-plugin plugin_config_fullspread.yaml
-	sleep 2
+	docker exec -e RUST_LOG=debug auditor-slurm-1 timeout 40s /auditor-priority-plugin plugin_config_fullspread.yaml
+	sleep 10
 
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part1 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" != "47041" ]; then exit 1; fi }
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part2 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" != "48348" ]; then exit 1; fi }
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part3 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" != "65335" ]; then exit 1; fi }
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part4 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" !=  "1634" ]; then exit 1; fi }
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part6 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" !=     "1" ]; then exit 1; fi }
-
+	
 	sleep 2
 }
 
 function test_priority_plugin_scaledbysum() {
 	sleep 1
-	docker exec -e RUST_LOG=debug auditor-slurm-1 /auditor-priority-plugin plugin_config_scaledbysum.yaml
-	sleep 2
+	docker exec -e RUST_LOG=debug auditor-slurm-1 timeout 40s /auditor-priority-plugin plugin_config_scaledbysum.yaml
+	sleep 10
 
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part1 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" != "18931" ]; then exit 1; fi }
 	docker exec auditor-slurm-1 /usr/bin/scontrol show Partition=part2 | grep PriorityJobFactor | awk '{print $1}' | awk -F "=" '{print $2}' | { read prio; if [ "$prio" != "19457" ]; then exit 1; fi }


### PR DESCRIPTION
This allows one to run the integration tests for the docker plugin when the repository was not cloned in a folder with name `Auditor`.